### PR TITLE
Bump docker-in-docker to v3 and disable Moby

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,9 @@
 {
 	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bullseye",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+		"ghcr.io/devcontainers/features/docker-in-docker:3": {
+			"moby": false
+		}
 	},
 	"customizations": {
 		"vscode": {


### PR DESCRIPTION
v3.0.x ships the containerd erofs snapshotter fix and per-container
/var/lib/containerd volume. Setting moby=false so the same config
works on Debian 13 (trixie) and Ubuntu 26.04 (resolute), where the
moby-cli packages are unavailable and the feature would otherwise
hard-exit.

https://claude.ai/code/session_01GG9qT1x5bayaeSBnS8PgAL