### PR TITLE
Bump default Node.js to 24 in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // More info: https://containers.dev/implementors/json_reference/
 {
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-24-bullseye",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:4": {
 			"moby": false


### PR DESCRIPTION
Bumps the repo's dev environment base image from Node.js 22 to 24.

The upstream image `mcr.microsoft.com/devcontainers/javascript-node:1-24-bullseye` is published and available, so the bump is safe.

This only affects `.devcontainer/devcontainer.json` (the environment used to develop this repo). The published `dotnet-node` template is unchanged — its `nodeVersion` option already defaults to `lts` (which currently resolves to Node 24) and lists `24` as a proposal.

Companion to #14 (docker-in-docker v4), which was verified to carry no breaking changes for this repo (it sets `moby: false` on a bullseye-based image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWy1L5CEthj87uZzJGvT4o)_