### PR TITLE
Move devcontainer base image to Debian trixie

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // More info: https://containers.dev/implementors/json_reference/
 {
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-24-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-24-trixie",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:4": {
 			"moby": false


### PR DESCRIPTION
Switches the dev environment base image from `javascript-node:1-24-bullseye` (Debian 11) to `1-24-trixie` (Debian 13, current stable).

docker-in-docker v4 remains compatible: this devcontainer sets `"moby": false`, which is required on trixie since the `moby` packages are not available there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWy1L5CEthj87uZzJGvT4o)_